### PR TITLE
refactor!: replace mdoc lib with our own lib 

### DIFF
--- a/lib/PEXv1.ts
+++ b/lib/PEXv1.ts
@@ -1,10 +1,11 @@
 import { Format, PresentationDefinitionV1, PresentationSubmission } from '@sphereon/pex-models';
-import { CredentialMapper, IPresentation, OriginalVerifiableCredential, OriginalVerifiablePresentation } from '@sphereon/ssi-types';
+import { IPresentation } from '@sphereon/ssi-types';
 
 import { PEX } from './PEX';
 import { EvaluationClientWrapper, EvaluationResults, PresentationEvaluationResults, SelectResults } from './evaluation';
 import { PresentationFromOpts, PresentationResult, PresentationSubmissionLocation } from './signing';
 import { SSITypesBuilder } from './types';
+import { OriginalVerifiableCredential, OriginalVerifiablePresentation, PexCredentialMapper } from './types/PexCredentialMapper';
 import { PresentationDefinitionV1VB, Validated, ValidationEngine } from './validation';
 
 /**
@@ -113,7 +114,9 @@ export class PEXv1 extends PEX {
       opts,
     );
 
-    const hasSdJwtCredentials = selectedCredentials.some((c) => CredentialMapper.isSdJwtDecodedCredential(c) || CredentialMapper.isSdJwtEncoded(c));
+    const hasSdJwtCredentials = selectedCredentials.some(
+      (c) => PexCredentialMapper.isSdJwtDecodedCredential(c) || PexCredentialMapper.isSdJwtEncoded(c),
+    );
 
     // We could include it in the KB-JWT? Not sure if we want that
     if (opts?.presentationSubmissionLocation === PresentationSubmissionLocation.PRESENTATION && hasSdJwtCredentials) {

--- a/lib/PEXv2.ts
+++ b/lib/PEXv2.ts
@@ -1,10 +1,11 @@
 import { Format, PresentationDefinitionV2, PresentationSubmission } from '@sphereon/pex-models';
-import { CredentialMapper, IPresentation, OriginalVerifiableCredential, OriginalVerifiablePresentation } from '@sphereon/ssi-types';
+import { IPresentation } from '@sphereon/ssi-types';
 
 import { PEX } from './PEX';
 import { EvaluationClientWrapper, EvaluationResults, PresentationEvaluationResults, SelectResults } from './evaluation';
 import { PresentationFromOpts, PresentationResult, PresentationSubmissionLocation } from './signing';
 import { SSITypesBuilder } from './types';
+import { OriginalVerifiableCredential, OriginalVerifiablePresentation, PexCredentialMapper } from './types/PexCredentialMapper';
 import { PresentationDefinitionV2VB, Validated, ValidationEngine } from './validation';
 
 /**
@@ -109,7 +110,9 @@ export class PEXv2 extends PEX {
       SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs(selectedCredentials),
       opts,
     );
-    const hasSdJwtCredentials = selectedCredentials.some((c) => CredentialMapper.isSdJwtDecodedCredential(c) || CredentialMapper.isSdJwtEncoded(c));
+    const hasSdJwtCredentials = selectedCredentials.some(
+      (c) => PexCredentialMapper.isSdJwtDecodedCredential(c) || PexCredentialMapper.isSdJwtEncoded(c),
+    );
 
     // We could include it in the KB-JWT? Not sure if we want that
     if (opts?.presentationSubmissionLocation === PresentationSubmissionLocation.PRESENTATION && hasSdJwtCredentials) {

--- a/lib/evaluation/core/evaluationResults.ts
+++ b/lib/evaluation/core/evaluationResults.ts
@@ -1,7 +1,8 @@
 import { PresentationSubmission } from '@sphereon/pex-models';
-import { IPresentation, IVerifiableCredential, OriginalVerifiablePresentation, SdJwtDecodedVerifiableCredential } from '@sphereon/ssi-types';
+import { IPresentation, IVerifiableCredential, SdJwtDecodedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { Checked, Status } from '../../ConstraintUtils';
+import { OriginalVerifiablePresentation } from '../../types/PexCredentialMapper';
 
 export interface PresentationEvaluationResults extends Omit<EvaluationResults, 'verifiableCredential'> {
   presentations: Array<OriginalVerifiablePresentation | IPresentation>;

--- a/lib/evaluation/core/selectResults.ts
+++ b/lib/evaluation/core/selectResults.ts
@@ -1,6 +1,5 @@
-import { OriginalVerifiableCredential } from '@sphereon/ssi-types';
-
 import { Checked, Status } from '../../ConstraintUtils';
+import { OriginalVerifiableCredential } from '../../types/PexCredentialMapper';
 
 import { SubmissionRequirementMatch } from './submissionRequirementMatch';
 

--- a/lib/evaluation/evaluationClient.ts
+++ b/lib/evaluation/evaluationClient.ts
@@ -1,9 +1,10 @@
 import { Format, PresentationSubmission } from '@sphereon/pex-models';
-import { IProofType, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { IProofType } from '@sphereon/ssi-types';
 
 import { Status } from '../ConstraintUtils';
 import { IInternalPresentationDefinition } from '../types';
 import PexMessages from '../types/Messages';
+import { WrappedVerifiableCredential } from '../types/PexCredentialMapper';
 import { filterToRestrictedDIDs, uniformDIDMethods } from '../utils';
 
 import { HandlerCheckResult } from './core';

--- a/lib/evaluation/handlers/abstractEvaluationHandler.ts
+++ b/lib/evaluation/handlers/abstractEvaluationHandler.ts
@@ -1,9 +1,9 @@
 import { JSONPath as jp } from '@astronautlabs/jsonpath';
 import { InputDescriptorV1, InputDescriptorV2, PresentationSubmission } from '@sphereon/pex-models';
-import { WrappedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition } from '../../types';
+import { WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';
 

--- a/lib/evaluation/handlers/didRestrictionEvaluationHandler.ts
+++ b/lib/evaluation/handlers/didRestrictionEvaluationHandler.ts
@@ -1,8 +1,7 @@
-import { CredentialMapper, WrappedVerifiableCredential } from '@sphereon/ssi-types';
-
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition, InternalPresentationDefinitionV1, InternalPresentationDefinitionV2 } from '../../types';
 import PexMessages from '../../types/Messages';
+import { PexCredentialMapper, WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { isRestrictedDID } from '../../utils';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';
@@ -39,13 +38,13 @@ export class DIDRestrictionEvaluationHandler extends AbstractEvaluationHandler {
   }
 
   private getIssuerIdFromWrappedVerifiableCredential(wrappedVc: WrappedVerifiableCredential) {
-    if (CredentialMapper.isW3cCredential(wrappedVc.credential)) {
+    if (PexCredentialMapper.isW3cCredential(wrappedVc.credential)) {
       return typeof wrappedVc.credential.issuer === 'object' ? wrappedVc.credential.issuer.id : wrappedVc.credential.issuer;
-    } else if (CredentialMapper.isSdJwtDecodedCredential(wrappedVc.credential)) {
+    } else if (PexCredentialMapper.isSdJwtDecodedCredential(wrappedVc.credential)) {
       return wrappedVc.credential.decodedPayload.iss;
     }
     // mdoc is not bound to did
-    else if (CredentialMapper.isWrappedMdocCredential(wrappedVc)) {
+    else if (PexCredentialMapper.isWrappedMdocCredential(wrappedVc)) {
       return undefined;
     }
     throw new Error('Unsupported credential type');

--- a/lib/evaluation/handlers/evaluationHandler.ts
+++ b/lib/evaluation/handlers/evaluationHandler.ts
@@ -1,6 +1,5 @@
-import { WrappedVerifiableCredential } from '@sphereon/ssi-types';
-
 import { IInternalPresentationDefinition } from '../../types/Internal.types';
+import { WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { EvaluationClient } from '../evaluationClient';
 
 export interface EvaluationHandler {

--- a/lib/evaluation/handlers/formatRestrictionEvaluationHandler.ts
+++ b/lib/evaluation/handlers/formatRestrictionEvaluationHandler.ts
@@ -1,8 +1,7 @@
-import { WrappedVerifiableCredential } from '@sphereon/ssi-types';
-
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition, InternalPresentationDefinitionV1, InternalPresentationDefinitionV2 } from '../../types';
 import PexMessages from '../../types/Messages';
+import { WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';
 
@@ -31,7 +30,7 @@ export class FormatRestrictionEvaluationHandler extends AbstractEvaluationHandle
 
         if (allowedFormats.includes(wvc.format)) {
           // According to 18013-7 the docType MUST match the input descriptor ID
-          if (wvc.format === 'mso_mdoc' && wvc.credential.docType.asStr !== _inputDescriptor.id) {
+          if (wvc.format === 'mso_mdoc' && wvc.credential.docType !== _inputDescriptor.id) {
             this.getResults().push(this.generateInputDescriptorIdDoctypeErrorResult(index, `$[${vcIndex}]`, wvc));
           }
 

--- a/lib/evaluation/handlers/inputDescriptorFilterEvaluationHandler.ts
+++ b/lib/evaluation/handlers/inputDescriptorFilterEvaluationHandler.ts
@@ -1,12 +1,12 @@
 import { JSONPath as jp } from '@astronautlabs/jsonpath';
 import { FieldV1, FieldV2 } from '@sphereon/pex-models';
-import { WrappedVerifiableCredential } from '@sphereon/ssi-types';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition, InternalPresentationDefinitionV2, PathComponent } from '../../types';
 import PexMessages from '../../types/Messages';
+import { WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { JsonPathUtils } from '../../utils';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';

--- a/lib/evaluation/handlers/limitDisclosureEvaluationHandler.ts
+++ b/lib/evaluation/handlers/limitDisclosureEvaluationHandler.ts
@@ -1,19 +1,18 @@
 import { InputDescriptorV1, InputDescriptorV2, Optionality } from '@sphereon/pex-models';
 import {
   AdditionalClaims,
-  CredentialMapper,
   ICredential,
   ICredentialSubject,
   IVerifiableCredential,
   SdJwtDecodedVerifiableCredential,
   SdJwtPresentationFrame,
-  WrappedVerifiableCredential,
 } from '@sphereon/ssi-types';
 
 import { ClaimValue } from '../../../test/types';
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition, InputDescriptorWithIndex, PathComponent } from '../../types';
 import PexMessages from '../../types/Messages';
+import { PexCredentialMapper, WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { applySdJwtLimitDisclosure, JsonPathUtils } from '../../utils';
 import { EvaluationClient } from '../evaluationClient';
 
@@ -91,7 +90,7 @@ export class LimitDisclosureEvaluationHandler extends AbstractEvaluationHandler 
   private enforceLimitDisclosure(wrappedVcs: WrappedVerifiableCredential[], eligibleInputDescriptors: InputDescriptorWithIndex[], vcIndex: number) {
     const wvc = wrappedVcs[vcIndex];
 
-    if (CredentialMapper.isWrappedSdJwtVerifiableCredential(wvc)) {
+    if (PexCredentialMapper.isWrappedSdJwtVerifiableCredential(wvc)) {
       const presentationFrame = this.createSdJwtPresentationFrame(eligibleInputDescriptors, wvc.credential, vcIndex);
 
       // We update the SD-JWT to it's presentation format (remove disclosures, update pretty payload, etc..), except
@@ -101,17 +100,17 @@ export class LimitDisclosureEvaluationHandler extends AbstractEvaluationHandler 
         wvc.decoded = wvc.credential.decodedPayload;
         // We need to overwrite the original, as that is returned in the selectFrom method
         // But we also want to keep the format of the original credential.
-        wvc.original = CredentialMapper.isSdJwtDecodedCredential(wvc.original) ? wvc.credential : wvc.credential.compactSdJwtVc;
+        wvc.original = PexCredentialMapper.isSdJwtDecodedCredential(wvc.original) ? wvc.credential : wvc.credential.compactSdJwtVc;
 
         for (const { inputDescriptorIndex, inputDescriptor } of eligibleInputDescriptors) {
           this.createSuccessResult(inputDescriptorIndex, `$[${vcIndex}]`, inputDescriptor.constraints?.limit_disclosure);
         }
       }
-    } else if (CredentialMapper.isWrappedMdocCredential(wvc)) {
+    } else if (PexCredentialMapper.isWrappedMdocCredential(wvc)) {
       for (const { inputDescriptorIndex, inputDescriptor } of eligibleInputDescriptors) {
         this.createSuccessResult(inputDescriptorIndex, `$[${vcIndex}]`, inputDescriptor.constraints?.limit_disclosure);
       }
-    } else if (CredentialMapper.isWrappedW3CVerifiableCredential(wvc)) {
+    } else if (PexCredentialMapper.isWrappedW3CVerifiableCredential(wvc)) {
       const internalCredentialToSend = this.createVcWithRequiredFields(eligibleInputDescriptors, wvc.credential, vcIndex);
       /* When verifiableCredentialToSend is null/undefined an error is raised, the credential will
        * remain untouched and the verifiable credential won't be submitted.

--- a/lib/evaluation/handlers/markForSubmissionEvaluationHandler.ts
+++ b/lib/evaluation/handlers/markForSubmissionEvaluationHandler.ts
@@ -1,10 +1,10 @@
 import { JSONPath as jp } from '@astronautlabs/jsonpath';
 import { InputDescriptorV1, InputDescriptorV2 } from '@sphereon/pex-models';
-import { WrappedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition } from '../../types/Internal.types';
 import PexMessages from '../../types/Messages';
+import { WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';
 

--- a/lib/evaluation/handlers/sameSubjectEvaluationHandler.ts
+++ b/lib/evaluation/handlers/sameSubjectEvaluationHandler.ts
@@ -1,9 +1,9 @@
 import { JSONPath as jp } from '@astronautlabs/jsonpath';
 import { HolderSubject, Optionality } from '@sphereon/pex-models';
-import { WrappedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition, PathComponent } from '../../types';
+import { WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';
 

--- a/lib/evaluation/handlers/subjectIsHolderEvaluationHandler.ts
+++ b/lib/evaluation/handlers/subjectIsHolderEvaluationHandler.ts
@@ -1,9 +1,10 @@
 import { JSONPath as jp } from '@astronautlabs/jsonpath';
 import { HolderSubject, Optionality } from '@sphereon/pex-models';
-import { ICredentialSubject, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { ICredentialSubject } from '@sphereon/ssi-types';
 
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition, PathComponent } from '../../types';
+import { WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';
 

--- a/lib/evaluation/handlers/subjectIsIssuerEvaluationHandler.ts
+++ b/lib/evaluation/handlers/subjectIsIssuerEvaluationHandler.ts
@@ -1,9 +1,10 @@
 import { ConstraintsV1, ConstraintsV2, Optionality } from '@sphereon/pex-models';
-import { CredentialMapper, IVerifiableCredential, SdJwtDecodedVerifiableCredential, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { IVerifiableCredential, SdJwtDecodedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition, InternalPresentationDefinitionV2, PathComponent } from '../../types';
 import PexMessages from '../../types/Messages';
+import { PexCredentialMapper, WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { getIssuerString, getSubjectIdsAsString, JsonPathUtils } from '../../utils';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';
@@ -46,11 +47,11 @@ export class SubjectIsIssuerEvaluationHandler extends AbstractEvaluationHandler 
           const issuer = getIssuerString(mapping.value);
           if (mapping && mapping.value && getSubjectIdsAsString(mapping.value).every((item) => item === issuer)) {
             this.getResults().push(
-              this.generateSuccessResult(idIdx, currentDescriptor.path, CredentialMapper.toWrappedVerifiableCredential(mapping.value)),
+              this.generateSuccessResult(idIdx, currentDescriptor.path, PexCredentialMapper.toWrappedVerifiableCredential(mapping.value)),
             );
           } else {
             this.getResults().push(
-              this.generateErrorResult(idIdx, currentDescriptor.path, CredentialMapper.toWrappedVerifiableCredential(mapping.value)),
+              this.generateErrorResult(idIdx, currentDescriptor.path, PexCredentialMapper.toWrappedVerifiableCredential(mapping.value)),
             );
           }
         }

--- a/lib/evaluation/handlers/uriEvaluationHandler.ts
+++ b/lib/evaluation/handlers/uriEvaluationHandler.ts
@@ -1,19 +1,13 @@
+import { IssuerSignedDocument } from '@animo-id/mdoc';
 import { JSONPath as jp } from '@astronautlabs/jsonpath';
 import { Descriptor, InputDescriptorV1, InputDescriptorV2 } from '@sphereon/pex-models';
-import {
-  CredentialMapper,
-  ICredential,
-  ICredentialSchema,
-  MdocDocument,
-  OriginalType,
-  SdJwtDecodedVerifiableCredential,
-  WrappedVerifiableCredential,
-} from '@sphereon/ssi-types';
+import { ICredential, ICredentialSchema, OriginalType, SdJwtDecodedVerifiableCredential } from '@sphereon/ssi-types';
 import { nanoid } from 'nanoid';
 
 import { Status } from '../../ConstraintUtils';
 import { IInternalPresentationDefinition, InternalPresentationDefinitionV1, PEVersion } from '../../types';
 import PexMessages from '../../types/Messages';
+import { PexCredentialMapper, WrappedVerifiableCredential } from '../../types/PexCredentialMapper';
 import { HandlerCheckResult } from '../core';
 import { EvaluationClient } from '../evaluationClient';
 
@@ -126,11 +120,11 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     }
   }
 
-  private static buildVcContextAndSchemaUris(credential: ICredential | SdJwtDecodedVerifiableCredential | MdocDocument, version: PEVersion) {
+  private static buildVcContextAndSchemaUris(credential: ICredential | SdJwtDecodedVerifiableCredential | IssuerSignedDocument, version: PEVersion) {
     const uris: string[] = [];
 
     // W3C credential
-    if (CredentialMapper.isW3cCredential(credential)) {
+    if (PexCredentialMapper.isW3cCredential(credential)) {
       if (Array.isArray(credential['@context'])) {
         credential['@context'].forEach((value) => uris.push(value as string));
       } else {
@@ -154,7 +148,7 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     // NOTE: we add the `vct` field of an SD-JWT to the list of uris, to allow SD-JWT
     // to work with PEX v1 in the same way that JWT vcs can work with pex v1. If we don't
     // add this, then SD-JWTs can only be used with PEX v2.
-    if (CredentialMapper.isSdJwtDecodedCredential(credential)) {
+    if (PexCredentialMapper.isSdJwtDecodedCredential(credential)) {
       if (version === PEVersion.v1) {
         uris.push(credential.decodedPayload.vct);
       }
@@ -174,8 +168,8 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     result.message = PexMessages.URI_EVALUATION_PASSED;
     result.payload = {
       format: wvc.format,
-      vcContext: CredentialMapper.isW3cCredential(wvc.credential) ? wvc.credential['@context'] : undefined,
-      vcCredentialSchema: CredentialMapper.isW3cCredential(wvc.credential) ? wvc.credential.credentialSchema : undefined,
+      vcContext: PexCredentialMapper.isW3cCredential(wvc.credential) ? wvc.credential['@context'] : undefined,
+      vcCredentialSchema: PexCredentialMapper.isW3cCredential(wvc.credential) ? wvc.credential.credentialSchema : undefined,
       inputDescriptorsUris,
     };
     return result;
@@ -192,8 +186,8 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     result.message = PexMessages.URI_EVALUATION_DIDNT_PASS;
     result.payload = {
       format: wvc.format,
-      vcContext: CredentialMapper.isW3cCredential(wvc.credential) ? wvc.credential['@context'] : undefined,
-      vcCredentialSchema: CredentialMapper.isW3cCredential(wvc.credential) ? wvc.credential.credentialSchema : undefined,
+      vcContext: PexCredentialMapper.isW3cCredential(wvc.credential) ? wvc.credential['@context'] : undefined,
+      vcCredentialSchema: PexCredentialMapper.isW3cCredential(wvc.credential) ? wvc.credential.credentialSchema : undefined,
       inputDescriptorsUris,
     };
     return result;

--- a/lib/signing/types.ts
+++ b/lib/signing/types.ts
@@ -5,7 +5,6 @@ import {
   IProof,
   IProofPurpose,
   IProofType,
-  OriginalVerifiableCredential,
   SdJwtDecodedVerifiableCredential,
   SdJwtVcKbJwtHeader,
   SdJwtVcKbJwtPayload,
@@ -13,6 +12,7 @@ import {
 } from '@sphereon/ssi-types';
 
 import { PresentationEvaluationResults } from '../evaluation';
+import { OriginalVerifiableCredential } from '../types/PexCredentialMapper';
 
 export interface ProofOptions {
   /**

--- a/lib/types/PexCredentialMapper.ts
+++ b/lib/types/PexCredentialMapper.ts
@@ -19,6 +19,7 @@ import {
   WrappedW3CVerifiableCredential,
   WrappedW3CVerifiablePresentation,
 } from '@sphereon/ssi-types';
+import * as u8a from 'uint8arrays';
 
 export interface WrappedMdocCredential {
   /**
@@ -286,19 +287,5 @@ function encodeMdocValue(value: unknown) {
 }
 
 function convertBase64urlToBinary(data: string) {
-  // Replace base64url characters back to base64
-  const base64 = data.replace(/-/g, '+').replace(/_/g, '/');
-
-  // Add padding if needed
-  const paddedBase64 = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
-
-  // Decode base64 to binary
-  const raw = atob(paddedBase64);
-  const rawLength = raw.length;
-  const array = new Uint8Array(new ArrayBuffer(rawLength));
-
-  for (let i = 0; i < rawLength; i++) {
-    array[i] = raw.charCodeAt(i);
-  }
-  return array;
+  return u8a.fromString(data, 'base64url');
 }

--- a/lib/types/PexCredentialMapper.ts
+++ b/lib/types/PexCredentialMapper.ts
@@ -90,6 +90,7 @@ export type WrappedVerifiableCredential = Exclude<_WrappedVerifiableCredential, 
 export type WrappedVerifiablePresentation = Exclude<_WrappedVerifiablePresentation, { format: 'mso_mdoc' }> | WrappedMdocPresentation;
 
 // NOTE: this is partial reimplementation of CredentialMapper from ssi-types to overwrite the
+// methods relying on Sphereon's mdoc implementation
 export class PexCredentialMapper {
   public static isMsoMdocDecodedPresentation(original: OriginalVerifiablePresentation): original is MDoc {
     return original instanceof MDoc;

--- a/lib/types/PexCredentialMapper.ts
+++ b/lib/types/PexCredentialMapper.ts
@@ -1,0 +1,303 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { cborEncode, DateOnly, IssuerSignedDocument, MDoc, parseDeviceResponse, parseIssuerSigned, uint8ArrayToBase64Url } from '@animo-id/mdoc';
+import {
+  WrappedVerifiableCredential as _WrappedVerifiableCredential,
+  WrappedVerifiablePresentation as _WrappedVerifiablePresentation,
+  CredentialMapper,
+  HasherSync,
+  ICredential,
+  IPresentation,
+  IVerifiablePresentation,
+  JwtDecodedVerifiableCredential,
+  JwtDecodedVerifiablePresentation,
+  OriginalType,
+  SdJwtDecodedVerifiableCredential,
+  W3CVerifiableCredential,
+  W3CVerifiablePresentation,
+  WrappedSdJwtVerifiableCredential,
+  WrappedSdJwtVerifiablePresentation,
+  WrappedW3CVerifiableCredential,
+  WrappedW3CVerifiablePresentation,
+} from '@sphereon/ssi-types';
+
+export interface WrappedMdocCredential {
+  /**
+   * Original IssuerSigned to Mdoc that we've received. Can be either the encoded or decoded variant.
+   */
+  original: IssuerSignedDocument | string;
+  /**
+   * Record where keys are the namespaces and the values are objects again with the namespace values
+   * @todo which types can be there? (it doesn't matter for matching as mdoc only matches on path)
+   */
+  decoded: MdocDecodedPayload;
+  /**
+   * Type of this credential.
+   */
+  type: OriginalType.MSO_MDOC_DECODED | OriginalType.MSO_MDOC_ENCODED;
+  /**
+   * The claim format, typically used during exchange transport protocols
+   */
+  format: 'mso_mdoc';
+  /**
+   * Internal stable representation of a Credential
+   */
+  credential: IssuerSignedDocument;
+}
+
+export interface WrappedMdocPresentation {
+  /**
+   * Original VP that we've received. Can be either the encoded or decoded variant.
+   */
+  original: MDoc | string;
+  /**
+   * Decoded version of the mdoc payload. This is the decoded payload, rather than the whole mdoc
+   */
+  decoded: MDoc;
+  /**
+   * Type of this Presentation.
+   */
+  type: OriginalType.MSO_MDOC_ENCODED | OriginalType.MSO_MDOC_DECODED;
+  /**
+   * The claim format, typically used during exchange transport protocols
+   */
+  format: 'mso_mdoc';
+  /**
+   * Internal stable representation of a Presentation
+   */
+  presentation: MDoc;
+  /**
+   * Wrapped Mdocs belonging to the Presentation. There can be multiple
+   * documents in a single device response
+   */
+  vcs: WrappedMdocCredential[];
+}
+
+export type OriginalVerifiablePresentation =
+  | W3CVerifiablePresentation
+  | JwtDecodedVerifiablePresentation
+  | SdJwtDecodedVerifiableCredential
+  | string
+  | MDoc;
+
+export type OriginalVerifiableCredential =
+  | W3CVerifiableCredential
+  | JwtDecodedVerifiableCredential
+  | SdJwtDecodedVerifiableCredential
+  | string
+  | IssuerSignedDocument;
+
+export type WrappedVerifiableCredential = Exclude<_WrappedVerifiableCredential, { format: 'mso_mdoc' }> | WrappedMdocCredential;
+export type WrappedVerifiablePresentation = Exclude<_WrappedVerifiablePresentation, { format: 'mso_mdoc' }> | WrappedMdocPresentation;
+
+// NOTE: this is partial reimplementation of CredentialMapper from ssi-types to overwrite the
+export class PexCredentialMapper {
+  public static isMsoMdocDecodedPresentation(original: OriginalVerifiablePresentation): original is MDoc {
+    return original instanceof MDoc;
+  }
+
+  public static isMsoMdocDecodedCredential(
+    original: OriginalVerifiableCredential | OriginalVerifiablePresentation | ICredential | IPresentation,
+  ): original is IssuerSignedDocument {
+    return original instanceof IssuerSignedDocument;
+  }
+
+  /**
+   * Decodes a Verifiable Presentation to a uniform format.
+   *
+   * When decoding SD-JWT credentials, a hasher implementation must be provided. The hasher implementation must be sync. When using
+   * an async hasher implementation, use the decodeSdJwtVcAsync method instead and you can provide the decoded payload to methods
+   * instead of the compact SD-JWT.
+   *
+   * @param presentation
+   * @param hasher Hasher implementation to use for SD-JWT decoding.
+   */
+  static decodeVerifiablePresentation(
+    presentation: OriginalVerifiablePresentation,
+    hasher?: HasherSync,
+  ): JwtDecodedVerifiablePresentation | IVerifiablePresentation | SdJwtDecodedVerifiableCredential | string | MDoc {
+    if (CredentialMapper.isMsoMdocOid4VPEncoded(presentation as any)) {
+      return presentation as string;
+    } else if (this.isMsoMdocDecodedPresentation(presentation)) {
+      return presentation as MDoc;
+    } else {
+      return CredentialMapper.decodeVerifiablePresentation(presentation, hasher) as any;
+    }
+  }
+
+  public static isW3cCredential(credential: ICredential | SdJwtDecodedVerifiableCredential | IssuerSignedDocument): credential is ICredential {
+    return CredentialMapper.isW3cCredential(credential as any);
+  }
+
+  /**
+   * Converts a presentation to a wrapped presentation.
+   *
+   * When decoding SD-JWT credentials, a hasher implementation must be provided. The hasher implementation must be sync. When using
+   * an async hasher implementation, use the decodeSdJwtVcAsync method instead and you can provide the decoded payload to methods
+   * instead of the compact SD-JWT.
+   *
+   * @param hasher Hasher implementation to use for SD-JWT decoding
+   */
+  static toWrappedVerifiablePresentation(
+    originalPresentation: OriginalVerifiablePresentation,
+    opts?: { maxTimeSkewInMS?: number; hasher?: HasherSync },
+  ): WrappedVerifiablePresentation {
+    // MSO_MDOC
+    if (this.isMsoMdocDecodedPresentation(originalPresentation) || CredentialMapper.isMsoMdocOid4VPEncoded(originalPresentation)) {
+      let deviceResponse: MDoc;
+      let originalType: OriginalType;
+      if (CredentialMapper.isMsoMdocOid4VPEncoded(originalPresentation as any)) {
+        deviceResponse = parseDeviceResponse(convertBase64urlToBinary(originalPresentation as string));
+        originalType = OriginalType.MSO_MDOC_ENCODED;
+      } else {
+        deviceResponse = originalPresentation as MDoc;
+        originalType = OriginalType.MSO_MDOC_DECODED;
+      }
+
+      const mdocCredentials = deviceResponse.documents?.map(
+        (doc) => PexCredentialMapper.toWrappedVerifiableCredential(doc, opts) as WrappedMdocCredential,
+      );
+      if (!mdocCredentials || mdocCredentials.length === 0) {
+        throw new Error('could not extract any mdoc credentials from mdoc device response');
+      }
+
+      return {
+        type: originalType,
+        format: 'mso_mdoc',
+        original: originalPresentation,
+        presentation: deviceResponse,
+        decoded: deviceResponse,
+        vcs: mdocCredentials,
+      };
+    }
+    return CredentialMapper.toWrappedVerifiablePresentation(originalPresentation, opts) as any;
+  }
+  /**
+   * Converts a credential to a wrapped credential.
+   *
+   * When decoding SD-JWT credentials, a hasher implementation must be provided. The hasher implementation must be sync. When using
+   * an async hasher implementation, use the decodeSdJwtVcAsync method instead and you can provide the decoded payload to methods
+   * instead of the compact SD-JWT.
+   *
+   * @param hasher Hasher implementation to use for SD-JWT decoding
+   */
+  static toWrappedVerifiableCredential(
+    verifiableCredential: OriginalVerifiableCredential,
+    opts?: { maxTimeSkewInMS?: number; hasher?: HasherSync },
+  ): WrappedVerifiableCredential {
+    // MSO_MDOC
+    if (this.isMsoMdocDecodedCredential(verifiableCredential) || CredentialMapper.isMsoMdocOid4VPEncoded(verifiableCredential)) {
+      let mdoc: IssuerSignedDocument;
+      if (CredentialMapper.isMsoMdocOid4VPEncoded(verifiableCredential as any)) {
+        mdoc = parseIssuerSigned(convertBase64urlToBinary(verifiableCredential as string));
+      } else {
+        mdoc = verifiableCredential as IssuerSignedDocument;
+      }
+
+      return {
+        type: CredentialMapper.isMsoMdocDecodedCredential(verifiableCredential as any)
+          ? OriginalType.MSO_MDOC_DECODED
+          : OriginalType.MSO_MDOC_ENCODED,
+        format: 'mso_mdoc',
+        original: verifiableCredential,
+        credential: mdoc,
+        decoded: getMdocDecodedPayload(mdoc),
+      };
+    }
+
+    return CredentialMapper.toWrappedVerifiableCredential(verifiableCredential, opts) as any;
+  }
+
+  public static isW3cPresentation(presentation: unknown): presentation is IPresentation {
+    return CredentialMapper.isW3cPresentation(presentation as any);
+  }
+
+  public static isWrappedSdJwtVerifiableCredential = (vc: unknown): vc is WrappedSdJwtVerifiableCredential =>
+    CredentialMapper.isWrappedSdJwtVerifiableCredential(vc as any);
+
+  public static isWrappedSdJwtVerifiablePresentation = (vc: unknown): vc is WrappedSdJwtVerifiablePresentation =>
+    CredentialMapper.isWrappedSdJwtVerifiablePresentation(vc as any);
+  public static isWrappedW3CVerifiableCredential = (vc: unknown): vc is WrappedW3CVerifiableCredential =>
+    CredentialMapper.isWrappedW3CVerifiableCredential(vc as any);
+  public static isWrappedW3CVerifiablePresentation = (vc: unknown): vc is WrappedW3CVerifiablePresentation =>
+    CredentialMapper.isWrappedW3CVerifiablePresentation(vc as any);
+  public static isWrappedMdocCredential = (vc: unknown): vc is WrappedMdocCredential => CredentialMapper.isWrappedMdocCredential(vc as any);
+  public static isWrappedMdocPresentation = (vc: unknown): vc is WrappedMdocPresentation => CredentialMapper.isWrappedMdocPresentation(vc as any);
+
+  public static isSdJwtDecodedCredential(original: unknown): original is SdJwtDecodedVerifiableCredential {
+    return CredentialMapper.isSdJwtDecodedCredential(original as any);
+  }
+  public static isJwtDecodedCredential(original: unknown): original is JwtDecodedVerifiableCredential {
+    return CredentialMapper.isJwtDecodedCredential(original as any);
+  }
+
+  public static isSdJwtEncoded(original: unknown): original is string {
+    return CredentialMapper.isSdJwtEncoded(original as any);
+  }
+
+  public static isJwtEncoded(original: unknown): original is string {
+    return CredentialMapper.isJwtEncoded(original as any);
+  }
+
+  public static decodeVerifiableCredential(credential: OriginalVerifiableCredential, hasher?: HasherSync) {
+    return CredentialMapper.decodeVerifiableCredential(credential as any, hasher);
+  }
+
+  public static isCredential(original: OriginalVerifiableCredential | OriginalVerifiablePresentation): original is OriginalVerifiableCredential {
+    return CredentialMapper.isCredential(original as any);
+  }
+
+  public static areOriginalVerifiableCredentialsEqual(firstOriginal: OriginalVerifiableCredential, secondOriginal: OriginalVerifiableCredential) {
+    if (this.isMsoMdocDecodedCredential(firstOriginal) || this.isMsoMdocDecodedCredential(secondOriginal)) {
+      return uint8ArrayToBase64Url(cborEncode(firstOriginal)) === uint8ArrayToBase64Url(cborEncode(secondOriginal));
+    }
+
+    return CredentialMapper.areOriginalVerifiableCredentialsEqual(firstOriginal, secondOriginal);
+  }
+}
+
+/**
+ * Record where keys are the namespaces and the values are objects again with the namespace values
+ */
+export type MdocDecodedPayload = Record<string, Record<string, string | number | boolean>>;
+export function getMdocDecodedPayload(mdoc: IssuerSignedDocument): MdocDecodedPayload {
+  const namespaces = mdoc.issuerSigned.nameSpaces;
+
+  const decodedPayload: MdocDecodedPayload = {};
+  for (const [namespace, items] of Array.from(namespaces.entries())) {
+    decodedPayload[namespace] = items.reduce(
+      (acc, item) => ({
+        ...acc,
+        [item.elementIdentifier]: encodeMdocValue(item.elementValue),
+      }),
+      {},
+    );
+  }
+
+  return decodedPayload;
+}
+
+function encodeMdocValue(value: unknown) {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'undefined' || value === null) return value;
+  if (value instanceof Date || value instanceof DateOnly) return value.toISOString();
+
+  // TODO: we don't want undefined, but empty object might also not work?
+  return {};
+}
+
+function convertBase64urlToBinary(data: string) {
+  // Replace base64url characters back to base64
+  const base64 = data.replace(/-/g, '+').replace(/_/g, '/');
+
+  // Add padding if needed
+  const paddedBase64 = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+
+  // Decode base64 to binary
+  const raw = atob(paddedBase64);
+  const rawLength = raw.length;
+  const array = new Uint8Array(new ArrayBuffer(rawLength));
+
+  for (let i = 0; i < rawLength; i++) {
+    array[i] = raw.charCodeAt(i);
+  }
+  return array;
+}

--- a/lib/types/SSITypesBuilder.ts
+++ b/lib/types/SSITypesBuilder.ts
@@ -4,14 +4,7 @@ import {
   PresentationDefinitionV1,
   PresentationDefinitionV2,
 } from '@sphereon/pex-models';
-import {
-  CredentialMapper,
-  JwtDecodedVerifiablePresentation,
-  OriginalVerifiableCredential,
-  OriginalVerifiablePresentation,
-  WrappedVerifiableCredential,
-  WrappedVerifiablePresentation,
-} from '@sphereon/ssi-types';
+import { JwtDecodedVerifiablePresentation } from '@sphereon/ssi-types';
 
 import { definitionVersionDiscovery, JsonPathUtils } from '../utils';
 
@@ -23,6 +16,13 @@ import {
   IPresentationDefinition,
   PEVersion,
 } from './Internal.types';
+import {
+  OriginalVerifiableCredential,
+  OriginalVerifiablePresentation,
+  PexCredentialMapper,
+  WrappedVerifiableCredential,
+  WrappedVerifiablePresentation,
+} from './PexCredentialMapper';
 
 export class SSITypesBuilder {
   public static modelEntityToInternalPresentationDefinitionV1(p: PdV1): InternalPresentationDefinitionV1 {
@@ -46,16 +46,15 @@ export class SSITypesBuilder {
   static mapExternalVerifiablePresentationToWrappedVP(
     presentation: OriginalVerifiablePresentation | JwtDecodedVerifiablePresentation,
   ): WrappedVerifiablePresentation {
-    return CredentialMapper.toWrappedVerifiablePresentation(presentation);
+    return PexCredentialMapper.toWrappedVerifiablePresentation(presentation);
   }
 
   static mapExternalVerifiableCredentialsToWrappedVcs(
     verifiableCredentials: OriginalVerifiableCredential | OriginalVerifiableCredential[],
   ): WrappedVerifiableCredential[] {
-    return CredentialMapper.toWrappedVerifiableCredentials(
-      Array.isArray(verifiableCredentials) ? verifiableCredentials : [verifiableCredentials],
-      {},
-    );
+    const array = Array.isArray(verifiableCredentials) ? verifiableCredentials : [verifiableCredentials];
+
+    return array.map((c) => PexCredentialMapper.toWrappedVerifiableCredential(c));
   }
 
   static toInternalPresentationDefinition(presentationDefinition: IPresentationDefinition): IInternalPresentationDefinition {

--- a/lib/utils/VCUtils.ts
+++ b/lib/utils/VCUtils.ts
@@ -1,6 +1,7 @@
-import { AdditionalClaims, CredentialMapper, ICredential, ICredentialSubject, IIssuer, SdJwtDecodedVerifiableCredential } from '@sphereon/ssi-types';
+import { AdditionalClaims, ICredential, ICredentialSubject, IIssuer, SdJwtDecodedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { DiscoveredVersion, IPresentationDefinition, PEVersion } from '../types';
+import { PexCredentialMapper } from '../types/PexCredentialMapper';
 import validatePDv1 from '../validation/validatePDv1.js';
 import validatePDv2 from '../validation/validatePDv2.js';
 import { ValidationError } from '../validation/validators';
@@ -9,7 +10,7 @@ import { ObjectUtils } from './ObjectUtils';
 import { JsonPathUtils } from './jsonPathUtils';
 
 export function getSubjectIdsAsString(vc: ICredential | SdJwtDecodedVerifiableCredential): string[] {
-  if (CredentialMapper.isSdJwtDecodedCredential(vc)) {
+  if (PexCredentialMapper.isSdJwtDecodedCredential(vc)) {
     // TODO: should we also handle `cnf` claim?
     return vc.signedPayload.sub ? [vc.signedPayload.sub] : [];
   }
@@ -19,7 +20,7 @@ export function getSubjectIdsAsString(vc: ICredential | SdJwtDecodedVerifiableCr
 }
 
 export function getIssuerString(vc: ICredential | SdJwtDecodedVerifiableCredential): string {
-  if (CredentialMapper.isSdJwtDecodedCredential(vc)) {
+  if (PexCredentialMapper.isSdJwtDecodedCredential(vc)) {
     return vc.signedPayload.iss;
   }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@animo-id/mdoc": "^0.5.2",
     "@astronautlabs/jsonpath": "^1.1.2",
     "@sd-jwt/decode": "^0.7.2",
     "@sd-jwt/present": "^0.7.2",
@@ -54,15 +55,15 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "jwt-decode": "^3.1.2",
-    "uint8arrays": "^3.1.1",
-    "nanoid": "^3.3.7"
+    "nanoid": "^3.3.7",
+    "uint8arrays": "^3.1.1"
   },
   "devDependencies": {
+    "@sd-jwt/core": "^0.7.2",
     "@types/jest": "^29.5.12",
     "@types/node": "^18.19.26",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
-    "@sd-jwt/core": "^0.7.2",
     "ajv-cli": "^5.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -72,12 +73,12 @@
     "npm-run-all": "^4.1.5",
     "open-cli": "^8.0.0",
     "prettier": "^3.2.5",
+    "release-it": "^17.4.1",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.1.2",
     "ts-json-schema-generator": "^1.5.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.2",
-    "release-it": "^17.4.1"
+    "typescript": "^5.4.2"
   },
   "files": [
     "index.ts",
@@ -91,6 +92,11 @@
   "prettier": {
     "singleQuote": true,
     "printWidth": 150
+  },
+  "pnpm": {
+    "overrides": {
+      "@sphereon/kmp-mdoc-core": "0.2.0-SNAPSHOT.27"
+    }
   },
   "packageManager": "pnpm@9.4.0+sha256.b6fd0bfda555e7e584ad7e56b30c68b01d5a04f9ee93989f4b93ca8473c49c74"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@sphereon/kmp-mdoc-core': 0.2.0-SNAPSHOT.27
+
 importers:
 
   .:
     dependencies:
+      '@animo-id/mdoc':
+        specifier: ^0.5.2
+        version: 0.5.2
       '@astronautlabs/jsonpath':
         specifier: ^1.1.2
         version: 1.1.2
@@ -112,6 +118,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@animo-id/mdoc@0.5.2':
+    resolution: {integrity: sha512-EQVsNOOeXFfBaEHkiKoh24jbSEQ1MORB/kUu0rnNrAEETpY5GK/H9iWevYFdmNDIqQTIEJlkU7S+sIj3pe66eA==}
 
   '@astronautlabs/jsonpath@1.1.2':
     resolution: {integrity: sha512-FqL/muoreH7iltYC1EB5Tvox5E8NSOOPGkgns4G+qxRKl6k5dxEVljUjB5NcKESzkqwnUqWjSZkL61XGYOuV+A==}
@@ -561,8 +570,9 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@sphereon/kmp-mdoc-core@0.2.0-SNAPSHOT.26':
-    resolution: {integrity: sha512-QXJ6R8ENiZV2rPMbn06cw5JKwqUYN1kzVRbYfONqE1PEXx1noQ4md7uxr2zSczi0ubKkNcbyYDNtIMTZIhGzmQ==}
+  '@sphereon/kmp-mdoc-core@0.2.0-SNAPSHOT.27':
+    resolution: {integrity: sha512-58vXp8Wu6e8Ugk2KZ6sISNhGNJtpm8g2i510sPIRa6E4Flo3SHC6AhInIDFoQgKyi/577wmBmKqBtdLok5jeNQ==}
+    bundledDependencies: []
 
   '@sphereon/pex-models@2.3.2':
     resolution: {integrity: sha512-foFxfLkRwcn/MOp/eht46Q7wsvpQGlO7aowowIIb5Tz9u97kYZ2kz6K2h2ODxWuv5CRA7Q0MY8XUBGE2lfOhOQ==}
@@ -1005,6 +1015,9 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -3133,6 +3146,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@animo-id/mdoc@0.5.2':
+    dependencies:
+      compare-versions: 6.1.1
+
   '@astronautlabs/jsonpath@1.1.2':
     dependencies:
       static-eval: 2.0.2
@@ -3730,7 +3747,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sphereon/kmp-mdoc-core@0.2.0-SNAPSHOT.26':
+  '@sphereon/kmp-mdoc-core@0.2.0-SNAPSHOT.27':
     dependencies:
       '@js-joda/core': 5.6.3
       '@js-joda/timezone': 2.3.0(@js-joda/core@5.6.3)
@@ -3742,7 +3759,7 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.6.1
       '@sd-jwt/decode': 0.9.2
-      '@sphereon/kmp-mdoc-core': 0.2.0-SNAPSHOT.26
+      '@sphereon/kmp-mdoc-core': 0.2.0-SNAPSHOT.27
       debug: 4.3.6
       events: 3.3.0
       jwt-decode: 4.0.0
@@ -4251,6 +4268,8 @@ snapshots:
   color-name@1.1.4: {}
 
   commander@11.1.0: {}
+
+  compare-versions@6.1.1: {}
 
   concat-map@0.0.1: {}
 

--- a/test/Mdoc.spec.ts
+++ b/test/Mdoc.spec.ts
@@ -93,7 +93,7 @@ describe('evaluate mdoc', () => {
     expect(result.areRequiredCredentialsPresent).toBe('info');
   });
 
-  it.only('selectFrom with mso_mdoc format where input descriptor id does not match doctype', () => {
+  it('selectFrom with mso_mdoc format where input descriptor id does not match doctype', () => {
     const pd = getPresentationDefinitionV2();
     pd.input_descriptors[0].id = 'random';
     const result = pex.selectFrom(pd, [mdocBase64UrlUniversity]);

--- a/test/PEX.spec.ts
+++ b/test/PEX.spec.ts
@@ -8,8 +8,6 @@ import {
   IProofType,
   IVerifiableCredential,
   IVerifiablePresentation,
-  OriginalVerifiableCredential,
-  WrappedVerifiablePresentation,
   WrappedW3CVerifiableCredential,
 } from '@sphereon/ssi-types';
 
@@ -17,6 +15,7 @@ import { IPresentationDefinition, PEX, PEXv2, Status, Validated } from '../lib';
 import { PresentationEvaluationResults } from '../lib/evaluation/core';
 import { PresentationSubmissionLocation, VerifiablePresentationResult } from '../lib/signing/types';
 import { SSITypesBuilder } from '../lib/types';
+import { OriginalVerifiableCredential } from '../lib/types/PexCredentialMapper';
 
 import {
   assertedMockCallback,
@@ -1380,7 +1379,7 @@ describe('evaluate', () => {
       ],
     };
     const jwtEncodedVp = getFile('./test/dif_pe_examples/vp/vp_universityDegree.jwt');
-    const wvp: WrappedVerifiablePresentation = SSITypesBuilder.mapExternalVerifiablePresentationToWrappedVP(jwtEncodedVp);
+    const wvp = SSITypesBuilder.mapExternalVerifiablePresentationToWrappedVP(jwtEncodedVp);
     const pex: PEX = new PEX();
     const vpr = await pex.verifiablePresentationFrom(pdSchema, [wvp.vcs[0].original], getAsyncCallbackWithoutProofType, {
       proofOptions: getProofOptionsMock(),

--- a/test/evaluation/evaluationClientWrapper.spec.ts
+++ b/test/evaluation/evaluationClientWrapper.spec.ts
@@ -7,7 +7,6 @@ import {
   ICredentialSubject,
   IVerifiableCredential,
   IVerifiablePresentation,
-  WrappedVerifiableCredential,
   WrappedW3CVerifiableCredential,
 } from '@sphereon/ssi-types';
 
@@ -15,6 +14,7 @@ import { Status } from '../../lib';
 import { EvaluationClient, EvaluationClientWrapper } from '../../lib/evaluation';
 import { InternalPresentationDefinitionV1, InternalPresentationDefinitionV2 } from '../../lib/types';
 import { SSITypesBuilder } from '../../lib/types';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 
 import { EvaluationClientWrapperData } from './EvaluationClientWrapperData';
 

--- a/test/evaluation/limitDisclosureEvaluationHandler.spec.ts
+++ b/test/evaluation/limitDisclosureEvaluationHandler.spec.ts
@@ -7,7 +7,6 @@ import {
   IProof,
   IVerifiableCredential,
   IVerifiablePresentation,
-  WrappedVerifiableCredential,
   WrappedW3CVerifiableCredential,
 } from '@sphereon/ssi-types';
 
@@ -15,6 +14,7 @@ import { Status } from '../../lib';
 import { EvaluationClient } from '../../lib/evaluation';
 import { InternalPresentationDefinitionV1, SSITypesBuilder } from '../../lib/types';
 import PexMessages from '../../lib/types/Messages';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 import { LimitDisclosureEvaluationResults } from '../test_data/limitDisclosureEvaluation/limitDisclosureEvaluationResults';
 import { PdMultiCredentials } from '../test_data/limitDisclosureEvaluation/pdMultiCredentials';
 import { VcMultiCredentials } from '../test_data/limitDisclosureEvaluation/vcMultiCredentials';

--- a/test/evaluation/restrictDIDHandler.spec.ts
+++ b/test/evaluation/restrictDIDHandler.spec.ts
@@ -1,12 +1,13 @@
 import fs from 'fs';
 
 import { PresentationSubmission } from '@sphereon/pex-models';
-import { IVerifiableCredential, IVerifiablePresentation, OriginalType, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { IVerifiableCredential, IVerifiablePresentation, OriginalType } from '@sphereon/ssi-types';
 
 import { Status } from '../../lib';
 import { EvaluationClient } from '../../lib/evaluation';
 import { DIDRestrictionEvaluationHandler } from '../../lib/evaluation/handlers';
 import { InternalPresentationDefinitionV1, SSITypesBuilder } from '../../lib/types';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 
 function getFile(path: string) {
   return JSON.parse(fs.readFileSync(path, 'utf-8'));

--- a/test/evaluation/restrictFormatHandler.spec.ts
+++ b/test/evaluation/restrictFormatHandler.spec.ts
@@ -1,12 +1,13 @@
 import fs from 'fs';
 
 import { PresentationSubmission } from '@sphereon/pex-models';
-import { IVerifiableCredential, IVerifiablePresentation, OriginalType, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { IVerifiableCredential, IVerifiablePresentation, OriginalType } from '@sphereon/ssi-types';
 
 import { Status } from '../../lib';
 import { EvaluationClient } from '../../lib/evaluation';
 import { FormatRestrictionEvaluationHandler } from '../../lib/evaluation/handlers';
 import { InternalPresentationDefinitionV1, SSITypesBuilder } from '../../lib/types';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 
 function getFile(path: string) {
   return JSON.parse(fs.readFileSync(path, 'utf-8'));

--- a/test/evaluation/selectFrom.spec.ts
+++ b/test/evaluation/selectFrom.spec.ts
@@ -1,13 +1,14 @@
 import fs from 'fs';
 
 import { SDJwt } from '@sd-jwt/core';
-import { defaultHasher, IVerifiableCredential, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { defaultHasher, IVerifiableCredential } from '@sphereon/ssi-types';
 
 import { PEX, Status } from '../../lib';
 import { EvaluationClientWrapper } from '../../lib/evaluation';
 import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 import { InternalPresentationDefinitionV1, InternalPresentationDefinitionV2, SSITypesBuilder } from '../../lib/types';
 import PexMessages from '../../lib/types/Messages';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 import { ClaimValue } from '../types';
 
 function getFile(path: string) {

--- a/test/evaluation/subjectIsIssuerEvaluationHandler.spec.ts
+++ b/test/evaluation/subjectIsIssuerEvaluationHandler.spec.ts
@@ -1,11 +1,12 @@
 import fs from 'fs';
 
-import { IVerifiableCredential, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { IVerifiableCredential } from '@sphereon/ssi-types';
 
 import { EvaluationClient } from '../../lib/evaluation';
 import { SubjectIsIssuerEvaluationHandler } from '../../lib/evaluation/handlers';
 import { InternalPresentationDefinitionV1, SSITypesBuilder } from '../../lib/types';
 import PexMessages from '../../lib/types/Messages';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 
 function getFile(path: string) {
   return JSON.parse(fs.readFileSync(path, 'utf-8'));

--- a/test/evaluation/submissionFrom.spec.ts
+++ b/test/evaluation/submissionFrom.spec.ts
@@ -1,11 +1,12 @@
 import fs from 'fs';
 
 import { PresentationSubmission } from '@sphereon/pex-models';
-import { IVerifiablePresentation, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { IVerifiablePresentation } from '@sphereon/ssi-types';
 
 import { IPresentationDefinition, PEX } from '../../lib';
 import { EvaluationClientWrapper } from '../../lib/evaluation';
 import { InternalPresentationDefinitionV1 } from '../../lib/types/Internal.types';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 import { SSITypesBuilder } from '../../lib/types/SSITypesBuilder';
 
 function getFile(path: string) {

--- a/test/evaluation/submissionRequirements.spec.ts
+++ b/test/evaluation/submissionRequirements.spec.ts
@@ -1,11 +1,12 @@
 import fs from 'fs';
 
 import { PresentationSubmission } from '@sphereon/pex-models';
-import { IVerifiablePresentation, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { IVerifiablePresentation } from '@sphereon/ssi-types';
 
 import { EvaluationClientWrapper } from '../../lib/evaluation';
 import { InternalPresentationDefinitionV1 } from '../../lib/types';
 import { SSITypesBuilder } from '../../lib/types';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 
 function getFile(path: string) {
   return JSON.parse(fs.readFileSync(path, 'utf-8'));

--- a/test/evaluation/uriEvaluationHandler.spec.ts
+++ b/test/evaluation/uriEvaluationHandler.spec.ts
@@ -1,12 +1,13 @@
 import fs from 'fs';
 
-import { IVerifiableCredential, IVerifiablePresentation, OriginalType, WrappedVerifiableCredential } from '@sphereon/ssi-types';
+import { IVerifiableCredential, IVerifiablePresentation, OriginalType } from '@sphereon/ssi-types';
 
 import { HandlerCheckResult, Status } from '../../lib';
 import { EvaluationClient } from '../../lib/evaluation';
 import { UriEvaluationHandler } from '../../lib/evaluation/handlers';
 import { InternalPresentationDefinitionV1, SSITypesBuilder } from '../../lib/types';
 import PexMessages from '../../lib/types/Messages';
+import { WrappedVerifiableCredential } from '../../lib/types/PexCredentialMapper';
 
 function getFile(path: string) {
   return JSON.parse(fs.readFileSync(path, 'utf-8'));


### PR DESCRIPTION
Replace mdoc lib with our own lib, to fix parsing issues we had with `keyAuthorizations` in received device response